### PR TITLE
UI Bug fixed - Issue with PlayArea and DrawCard

### DIFF
--- a/app/components/contexts/GameContext.tsx
+++ b/app/components/contexts/GameContext.tsx
@@ -473,26 +473,23 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({
 
   /**
    * Draw a card from the deck for the current player, skipping validity checks.
+   * If the player had cards in the play area (selected but not played), return them to the hand along with the drawn card.
    */
   const drawCard = () => {
     if (deckSize > 0) {
       const newCard = deck.pop();
       if (newCard) {
         if (currentPlayer === "player") {
+          // Return any selected (play-area) cards to hand, then add the drawn card
           setPlayerHand((prevHand) => {
-            // Calculate next position for the new card
-            const index = prevHand.length;
-            const cardWidth = 70;
-            const cardHeight = 50;
-            // Place drawn card at a fixed position (e.g., Row 2, far right)
-            // Minimal initial position for drawn card
             const cardWithPosition: CardType = {
               ...newCard,
               position: { x: 0, y: 0 },
               hasBeenDragged: false,
             };
-            return [...prevHand, cardWithPosition];
+            return [...prevHand, ...selectedCards, cardWithPosition];
           });
+          setSelectedCards([]);
           setGameMessage("Player drew a card. Computer's turn.");
         } else {
           setComputerHand((prev) => [...prev, newCard]);


### PR DESCRIPTION
## UI Bug fixed - Issue with PlayArea and DrawCard

### **What was wrong**  
Choosing cards to play moves them from `playerHand` into `selectedCards` (they show in the play area). If the player then clicked **Draw Card**, `drawCard()` only added the new card to the hand and never put `selectedCards` back. Those cards stayed in play area state with `selectedCards` so they were they were still hanging around “in the play area.”

### **What was changed**  
In `drawCard()` in `GameContext.tsx`, when the current player is the human:

- **Return selected cards to the hand** – The hand update now adds both the existing hand and the current `selectedCards`: `[...prevHand, ...selectedCards, cardWithPosition]`.
- **Clear the play area** – After updating the hand, we call `setSelectedCards([])` so the play area is cleared.

### So when a player has cards in the play area and then draws:

- Those cards go back into their hand.
- The new card is added to their hand.
- The play area is cleared.
- The turn still switches to the computer as before.